### PR TITLE
Fix creating invalid appmanifests

### DIFF
--- a/tools/pysteambridge/download.py
+++ b/tools/pysteambridge/download.py
@@ -25,7 +25,7 @@ def do(appid):
 
   with open(manifest.filename(), 'w') as f:
     f.write('"AppState"\n')
-    f.write('{\n"')
+    f.write('{\n')
     f.write('\t"AppID"\t"{}"\n'.format(manifest.appid()))
     f.write('\t"Universe"\t"1"\n')
     f.write('\t"StateFlags"\t"1026"\n')


### PR DESCRIPTION
Posted the issue THEN found the thing.

The " after \n shouldn't be there.
